### PR TITLE
Add budget diagnostic homepage

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,0 +1,25 @@
+.resultCard {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+}
+
+.loader {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #187072;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.coachingSuggestion {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- create a styled budget diagnostic form
- implement budget profile logic and animated loader
- show result card with coaching suggestion
- add page module CSS for loader and result card styling

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d49a6eef8832eb6e889071a70fc40