### PR TITLE
Ajout login Firebase et pages légales

### DIFF
--- a/src/app/cgu/page.tsx
+++ b/src/app/cgu/page.tsx
@@ -1,0 +1,18 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function CGU() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 text-[#363945]">
+        <h1 className="text-2xl font-bold text-center text-[#26436E] mb-6">Conditions générales d’utilisation</h1>
+        <p className="mb-4">L’utilisation du site MoneyTime Rev’ implique l’acceptation pleine et entière des présentes CGU.</p>
+        <p className="mb-4">L’utilisateur s’engage à fournir des informations exactes et à respecter la législation en vigueur.</p>
+        <p className="mb-4">MoneyTime Rev’ se réserve le droit de modifier ces conditions à tout moment.</p>
+        <p>En continuant à naviguer sur le site, vous acceptez ces conditions sans réserve.</p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/components/CookieBanner.tsx
+++ b/src/app/components/CookieBanner.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useState, useEffect } from "react";
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const accepted = localStorage.getItem("cookie_ok");
+    if (!accepted) setVisible(true);
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem("cookie_ok", "1");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-[#26436E] text-white text-sm p-4 flex justify-between items-center z-50">
+      <span>Nous utilisons des cookies à des fins statistiques uniquement. En continuant, vous acceptez leur utilisation.</span>
+      <button onClick={accept} className="ml-4 px-3 py-1 bg-white text-[#26436E] rounded">OK</button>
+    </div>
+  );
+}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,10 +1,25 @@
+"use client";
+import Link from "next/link";
+
 export default function Footer() {
   return (
-    <footer className="bg-white border-t border-[#e2e8f0] text-center text-sm text-[#6e6e73] py-6 mt-12">
-      <p className="mb-2 font-medium">© 2025 MoneyTime Rev’ — Tous droits réservés.</p>
-      <p className="text-xs">
-        Site informatif à visée pédagogique. Les conseils ne remplacent pas un accompagnement individualisé.
-      </p>
+    <footer className="bg-[#f8f9fa] text-[#4a4a4a] text-sm mt-12 border-t border-gray-200">
+      <div className="max-w-5xl mx-auto px-4 py-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="space-y-2">
+          <Link href="/cgu" className="block hover:underline">CGU</Link>
+          <Link href="/mentions-legales" className="block hover:underline">Mentions légales</Link>
+          <Link href="/politique-de-confidentialite" className="block hover:underline">Politique de confidentialité</Link>
+          <Link href="/contact" className="block hover:underline">Contact</Link>
+        </div>
+        <div className="space-y-2 text-xs">
+          <p>Éditeur : MoneyTime Rev’</p>
+          <p>Hébergeur : Google Cloud Platform</p>
+          <p>Les données collectées sont traitées dans le respect du RGPD.</p>
+        </div>
+        <div className="text-xs md:text-right flex items-end justify-center md:justify-end">
+          © 2025 MoneyTime Rev’ – Tous droits réservés
+        </div>
+      </div>
     </footer>
   );
 }

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,7 +1,16 @@
 "use client";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../lib/firebase";
 
 export default function Header() {
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, user => setConnected(!!user));
+  }, []);
+
   return (
     <header className="bg-white shadow-sm border-b border-[#e2e8f0]">
       <div className="max-w-5xl mx-auto px-4 py-3 flex justify-between items-center">
@@ -10,9 +19,13 @@ export default function Header() {
         </span>
         <nav className="space-x-4 text-sm font-semibold text-[#187072]">
           <Link href="/" className="hover:underline">Accueil</Link>
-          <Link href="/offres" className="hover:underline">Offres</Link>
+          <Link href="/" className="hover:underline">Diagnostic</Link>
           <Link href="/contact" className="hover:underline">Contact</Link>
-          <Link href="/mentions-legales" className="hover:underline">Mentions légales</Link>
+          {connected ? (
+            <Link href="/dashboard" className="hover:underline">Mon espace</Link>
+          ) : (
+            <Link href="/login" className="hover:underline">Connexion</Link>
+          )}
         </nav>
       </div>
     </header>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,28 +1,15 @@
-'use client'
-
-import { useState } from 'react'
+import Header from '../components/Header';
+import Footer from '../components/Footer';
 
 export default function Contact() {
-  const [form, setForm] = useState({ name: '', email: '', message: '' })
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value })
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    alert('Message envoyé ! (non connecté)')
-  }
-
-  return (
-    <main style={{ padding: '2rem', maxWidth: '600px', margin: 'auto' }}>
-      <h1>Contact</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <input type="text" name="name" placeholder="Votre nom" value={form.name} onChange={handleChange} required />
-        <input type="email" name="email" placeholder="Votre email" value={form.email} onChange={handleChange} required />
-        <textarea name="message" placeholder="Votre message" value={form.message} onChange={handleChange} required />
-        <button type="submit">Envoyer</button>
-      </form>
-    </main>
-  )
+  return (    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 text-[#363945]">
+        <h1 className="text-2xl font-bold text-center text-[#26436E] mb-6">Contact</h1>
+        <p className="mb-4">Pour toute question, vous pouvez nous écrire à l’adresse suivante&nbsp;: <a href="mailto:contact@moneytimerev.fr" className="text-[#187072] underline">contact@moneytimerev.fr</a>.</p>
+        <p>Nous vous répondrons dans les meilleurs délais.</p>
+      </main>
+      <Footer />
+    </>
+  );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { auth, db } from "../lib/firebase";
+import { onAuthStateChanged, signOut } from "firebase/auth";
+import { collection, query, where, orderBy, getDocs } from "firebase/firestore";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+interface Diagnostic {
+  id: string;
+  prenom?: string;
+  nom?: string;
+  email?: string;
+  createdAt?: any;
+}
+
+export default function Dashboard() {
+  const [user, setUser] = useState<any>(null);
+  const [admin, setAdmin] = useState(false);
+  const [diagnostics, setDiagnostics] = useState<Diagnostic[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, async u => {
+      if (!u) {
+        router.replace("/login");
+        return;
+      }
+      setUser(u);
+      const isAdmin = u.email === "frederic.francia@icloud.com";
+      setAdmin(isAdmin);
+      const baseQuery = isAdmin
+        ? query(collection(db, "diagnostics"), orderBy("createdAt", "desc"))
+        : query(collection(db, "diagnostics"), where("email", "==", u.email), orderBy("createdAt", "desc"));
+      const snap = await getDocs(baseQuery);
+      const data = snap.docs.map(d => ({ id: d.id, ...d.data() } as Diagnostic));
+      setDiagnostics(data);
+    });
+  }, [router]);
+
+  const logout = async () => {
+    await signOut(auth);
+    router.replace("/");
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-5xl mx-auto p-4 mt-6">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold text-[#26436E]">Tableau de bord</h1>
+          <button onClick={logout} className="text-sm text-red-600">Se déconnecter</button>
+        </div>
+        {admin ? (
+          <div className="space-y-4">
+            {diagnostics.map(d => (
+              <div key={d.id} className="border p-3 rounded">
+                <p className="font-semibold">{d.prenom} {d.nom}</p>
+                <p className="text-sm text-gray-600">{d.email}</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {diagnostics.map(d => (
+              <div key={d.id} className="border p-3 rounded">
+                <p className="font-semibold">Diagnostic du {new Date(d.createdAt?.seconds * 1000).toLocaleDateString()}</p>
+              </div>
+            ))}
+            <a href="https://calendly.com" className="block text-center bg-[#187072] text-white py-2 rounded mt-4">Prendre rendez-vous</a>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import { Nunito } from 'next/font/google'
+import CookieBanner from './components/CookieBanner'
 
 const nunito = Nunito({
   subsets: ['latin'],
@@ -10,7 +11,10 @@ const nunito = Nunito({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="fr" className={nunito.variable}>
-      <body>{children}</body>
+      <body>
+        {children}
+        <CookieBanner />
+      </body>
     </html>
   )
 }

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -1,7 +1,9 @@
 import { getApps, initializeApp } from 'firebase/app'
 import { getFirestore } from 'firebase/firestore'
+import { getAuth } from 'firebase/auth'
 import { firebaseConfig } from '../../lib/firebase'
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig)
 
 export const db = getFirestore(app)
+export const auth = getAuth(app)

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { auth } from "../lib/firebase";
+import { signInWithEmailAndPassword, onAuthStateChanged } from "firebase/auth";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, user => {
+      if (user) router.replace("/dashboard");
+    });
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signInWithEmailAndPassword(auth, email, password);
+    router.replace("/dashboard");
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-sm mx-auto p-4 mt-8">
+        <h1 className="text-2xl font-bold text-center text-[#26436E] mb-6">Connexion</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="w-full border p-2 rounded" required />
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Mot de passe" className="w-full border p-2 rounded" required />
+          <button type="submit" className="w-full bg-[#187072] text-white py-2 rounded">Se connecter</button>
+        </form>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/mentions-legales/page.tsx
+++ b/src/app/mentions-legales/page.tsx
@@ -1,51 +1,17 @@
-import Header from '../components/Header'
-import Footer from '../components/Footer'
+import Header from '../components/Header';
+import Footer from '../components/Footer';
 
 export default function MentionsLegales() {
   return (
     <>
       <Header />
-      <main style={{
-        maxWidth: 720,
-        margin: '48px auto 32px auto',
-        padding: '0 16px',
-        fontFamily: "'Nunito', Arial, sans-serif",
-        color: '#363945',
-      }}>
-        <h1 style={{
-          color: '#26436E',
-          fontWeight: 900,
-          fontSize: '2em',
-          marginBottom: 30,
-          textAlign: 'center',
-        }}>
-          Mentions légales
-        </h1>
-        <section style={{
-          background: '#fff',
-          borderRadius: 12,
-          padding: 24,
-          boxShadow: '0 2px 12px rgba(38,67,110,0.07)',
-          fontSize: '1.04em',
-          lineHeight: 1.7,
-        }}>
-          <strong>Éditeur du site</strong><br />
-          MoneyTime Rev’<br />
-          Responsable de la publication : Frédéric Francia<br />
-          Contact : contact@moneytimerev.fr
-          <br /><br />
-          <strong>Hébergement</strong><br />
-          Google Cloud Platform<br />
-          8 rue de Londres, 75009 Paris, France
-          <br /><br />
-          <strong>Propriété intellectuelle</strong><br />
-          L’ensemble de ce site relève de la législation française et internationale sur le droit d’auteur et la propriété intellectuelle. Toute reproduction totale ou partielle est interdite sans autorisation expresse.
-          <br /><br />
-          <strong>Protection des données personnelles</strong><br />
-          Les informations recueillies via les formulaires sont réservées à l’usage exclusif de MoneyTime Rev’. Conformément à la loi “Informatique et Libertés”, vous disposez d’un droit d’accès, de rectification et de suppression de vos données.
-        </section>
+      <main className="max-w-3xl mx-auto p-4 mt-6 text-[#363945]">
+        <h1 className="text-2xl font-bold text-center text-[#26436E] mb-6">Mentions légales</h1>
+        <p className="mb-4">Éditeur : MoneyTime Rev’ – contact@moneytimerev.fr</p>
+        <p className="mb-4">Hébergeur : Google Cloud Platform – 8 rue de Londres, 75009 Paris</p>
+        <p className="mb-4">Les contenus de ce site sont protégés par le droit d’auteur. Toute reproduction est interdite sans autorisation.</p>
+        <p>Les données personnelles collectées sont utilisées uniquement pour répondre aux demandes et sont traitées conformément à la réglementation.</p>
       </main>
       <Footer />
-    </>
-  )
+    </>  );
 }

--- a/src/app/politique-de-confidentialite/page.tsx
+++ b/src/app/politique-de-confidentialite/page.tsx
@@ -1,0 +1,17 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function Confidentialite() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 text-[#363945]">
+        <h1 className="text-2xl font-bold text-center text-[#26436E] mb-6">Politique de confidentialité</h1>
+        <p className="mb-4">Les informations recueillies sont destinées uniquement à MoneyTime Rev’ pour le suivi des demandes.</p>
+        <p className="mb-4">Vous disposez d’un droit d’accès, de rectification et de suppression de vos données en nous contactant à l’adresse indiquée.</p>
+        <p>Ces données ne sont en aucun cas cédées ou vendues à des tiers.</p>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- ajouter bannière cookies et nouveau footer
- connecter le header à Firebase Auth
- créer la page de connexion
- ajouter un tableau de bord simple
- ajouter les pages légales

## Testing
- `npm run lint` *(échoue: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d56861f4c832eb1ece28fe7ee2c59