### PR TITLE
Add admin/client areas with Firebase auth

### DIFF
--- a/src/app/admin/diagnostics/page.tsx
+++ b/src/app/admin/diagnostics/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export default function AdminDiagnostics() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6">
+        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Diagnostics</h1>
+        <p>&lt;accès aux diagnostics&gt;</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import Link from 'next/link'
+
+export default function AdminHome() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 space-y-4">
+        <h1 className="text-2xl font-bold text-[#26436E]">Espace admin</h1>
+        <Link href="/admin/utilisateurs" className="text-[#187072] underline">
+          Gérer les utilisateurs
+        </Link>
+        <Link href="/admin/diagnostics" className="text-[#187072] underline">
+          Diagnostics
+        </Link>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/admin/utilisateurs/[uid]/page.tsx
+++ b/src/app/admin/utilisateurs/[uid]/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../../components/Header'
+import Footer from '../../../components/Footer'
+
+export default function AdminUserDetail({ params }: { params: { uid: string } }) {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6">
+        <h1 className="text-2xl font-bold text-[#26436E] mb-4">
+          Fiche utilisateur {params.uid}
+        </h1>
+        <p>&lt;détails du client&gt;</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/admin/utilisateurs/page.tsx
+++ b/src/app/admin/utilisateurs/page.tsx
@@ -1,0 +1,22 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+import Link from 'next/link'
+
+export default function AdminUsers() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 space-y-4">
+        <h1 className="text-2xl font-bold text-[#26436E]">Utilisateurs</h1>
+        <p>&lt;liste des utilisateurs avec rôles et plans modifiables&gt;</p>
+        <Link href="/admin/utilisateurs/123" className="text-[#187072] underline">
+          Voir fiche utilisateur
+        </Link>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/api/update-plan/route.ts
+++ b/src/app/api/update-plan/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { adminDb } from '@/lib/firebaseAdmin'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { uid, plan } = await req.json()
+    if (!uid || !plan) {
+      return NextResponse.json({ error: 'Missing parameters' }, { status: 400 })
+    }
+    await adminDb.collection('utilisateurs').doc(uid).update({ plan })
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to update plan' }, { status: 500 })
+  }
+}

--- a/src/app/api/verify-session/route.ts
+++ b/src/app/api/verify-session/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { adminAuth, adminDb } from '@/lib/firebaseAdmin'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { idToken } = await req.json()
+    if (!idToken) {
+      return NextResponse.json({ error: 'Missing token' }, { status: 400 })
+    }
+    const decoded = await adminAuth.verifyIdToken(idToken)
+    const snap = await adminDb
+      .collection('utilisateurs')
+      .doc(decoded.uid)
+      .get()
+    const role = snap.exists ? snap.data()?.role ?? 'client' : 'client'
+    return NextResponse.json({ uid: decoded.uid, email: decoded.email, role })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+  }
+}

--- a/src/app/client/coaching/page.tsx
+++ b/src/app/client/coaching/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export default function ClientCoaching() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6">
+        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Coaching</h1>
+        <p>&lt;outil de coaching personnel&gt;</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -1,0 +1,30 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+
+export default function ClientHome() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6 space-y-4">
+        <h1 className="text-2xl font-bold text-[#26436E]">Espace client</h1>
+        <p>Plan actif : &lt;plan&gt;</p>
+        <p>RDV restants : &lt;nombre&gt;</p>
+        <button className="bg-[#187072] text-white py-2 px-4 rounded">
+          Prendre rendez-vous
+        </button>
+        <div>
+          <h2 className="font-semibold">Historique</h2>
+          <p>&lt;historique&gt;</p>
+        </div>
+        <div>
+          <h2 className="font-semibold">Suivi personnel</h2>
+          <p>&lt;outil de suivi&gt;</p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/client/profil/page.tsx
+++ b/src/app/client/profil/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export default function ClientProfil() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6">
+        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mon profil</h1>
+        <p>&lt;informations du profil utilisateur&gt;</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/client/rendez-vous/page.tsx
+++ b/src/app/client/rendez-vous/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export default function ClientRendezVous() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto p-4 mt-6">
+        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mes rendez-vous</h1>
+        <p>&lt;gestion des rendez-vous&gt;</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,0 +1,17 @@
+import { getApps, initializeApp, cert } from 'firebase-admin/app'
+import { getAuth } from 'firebase-admin/auth'
+import { getFirestore } from 'firebase-admin/firestore'
+
+const app =
+  getApps().length > 0
+    ? getApps()[0]
+    : initializeApp({
+        credential: cert({
+          projectId: process.env.FIREBASE_PROJECT_ID,
+          clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+          privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+        }),
+      })
+
+export const adminAuth = getAuth(app)
+export const adminDb = getFirestore(app)


### PR DESCRIPTION
## Summary
- create firebase-admin initialization helper
- add API route to verify session
- add placeholder API route to update plans
- implement client area with profile, rendez-vous and coaching pages
- implement admin area with diagnostics and user management pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8ca434c8832ebb90e9d5e7297fed