### PR TITLE
Improve client dashboard routing

### DIFF
--- a/src/app/client/coaching/page.tsx
+++ b/src/app/client/coaching/page.tsx
@@ -1,18 +1,12 @@
 "use client"
 export const dynamic = "force-dynamic"
 
-import Header from '../../components/Header'
-import Footer from '../../components/Footer'
 
 export default function ClientCoaching() {
   return (
-    <>
-      <Header />
-      <main className="max-w-3xl mx-auto p-4 mt-6">
-        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Coaching</h1>
-        <p>&lt;outil de coaching personnel&gt;</p>
-      </main>
-      <Footer />
-    </>
+    <main className="max-w-3xl mx-auto p-4 mt-6">
+      <h1 className="text-2xl font-bold text-[#26436E] mb-4">Coaching</h1>
+      <p>&lt;outil de coaching personnel&gt;</p>
+    </main>
   )
 }

--- a/src/app/client/dashboard/page.tsx
+++ b/src/app/client/dashboard/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+export const dynamic = "force-dynamic"
+
+import Tabs, { Tab } from '../../components/Tabs'
+
+export default function ClientDashboard() {
+  const tabs: Tab[] = [
+    { label: 'Vue globale', content: <p>&lt;courbes d\'évolution&gt;</p> },
+    { label: 'Mon mois', content: <p>&lt;analyse du mois en euros&gt;</p> },
+    { label: 'Mon relevé', content: <p>&lt;liste des opérations&gt;</p> },
+    { label: 'Mes comptes', content: <p>&lt;gestion des comptes&gt;</p> },
+    { label: 'Suivi coaching', content: <p>&lt;progression coaching&gt;</p> },
+  ]
+
+  return <Tabs tabs={tabs} />
+}

--- a/src/app/client/layout.tsx
+++ b/src/app/client/layout.tsx
@@ -1,0 +1,13 @@
+import '../globals.css'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main className="max-w-5xl mx-auto p-4 mt-6">{children}</main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -1,30 +1,25 @@
 "use client"
 export const dynamic = "force-dynamic"
 
-import Header from '../components/Header'
-import Footer from '../components/Footer'
+import Link from 'next/link'
 
 export default function ClientHome() {
   return (
-    <>
-      <Header />
-      <main className="max-w-3xl mx-auto p-4 mt-6 space-y-4">
-        <h1 className="text-2xl font-bold text-[#26436E]">Espace client</h1>
-        <p>Plan actif : &lt;plan&gt;</p>
-        <p>RDV restants : &lt;nombre&gt;</p>
-        <button className="bg-[#187072] text-white py-2 px-4 rounded">
-          Prendre rendez-vous
-        </button>
-        <div>
-          <h2 className="font-semibold">Historique</h2>
-          <p>&lt;historique&gt;</p>
-        </div>
-        <div>
-          <h2 className="font-semibold">Suivi personnel</h2>
-          <p>&lt;outil de suivi&gt;</p>
-        </div>
-      </main>
-      <Footer />
-    </>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-[#26436E]">Espace client</h1>
+      <p>Plan actif : &lt;plan&gt;</p>
+      <p>RDV restants : &lt;nombre&gt;</p>
+      <Link href="/client/dashboard" className="bg-[#187072] text-white py-2 px-4 rounded inline-block">
+        Accéder au tableau de bord
+      </Link>
+      <div>
+        <h2 className="font-semibold">Historique</h2>
+        <p>&lt;historique&gt;</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">Suivi personnel</h2>
+        <p>&lt;outil de suivi&gt;</p>
+      </div>
+    </div>
   )
 }

--- a/src/app/client/profil/page.tsx
+++ b/src/app/client/profil/page.tsx
@@ -1,18 +1,12 @@
 "use client"
 export const dynamic = "force-dynamic"
 
-import Header from '../../components/Header'
-import Footer from '../../components/Footer'
 
 export default function ClientProfil() {
   return (
-    <>
-      <Header />
-      <main className="max-w-3xl mx-auto p-4 mt-6">
-        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mon profil</h1>
-        <p>&lt;informations du profil utilisateur&gt;</p>
-      </main>
-      <Footer />
-    </>
+    <main className="max-w-3xl mx-auto p-4 mt-6">
+      <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mon profil</h1>
+      <p>&lt;informations du profil utilisateur&gt;</p>
+    </main>
   )
 }

--- a/src/app/client/rendez-vous/page.tsx
+++ b/src/app/client/rendez-vous/page.tsx
@@ -1,18 +1,12 @@
 "use client"
 export const dynamic = "force-dynamic"
 
-import Header from '../../components/Header'
-import Footer from '../../components/Footer'
 
 export default function ClientRendezVous() {
   return (
-    <>
-      <Header />
-      <main className="max-w-3xl mx-auto p-4 mt-6">
-        <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mes rendez-vous</h1>
-        <p>&lt;gestion des rendez-vous&gt;</p>
-      </main>
-      <Footer />
-    </>
+    <main className="max-w-3xl mx-auto p-4 mt-6">
+      <h1 className="text-2xl font-bold text-[#26436E] mb-4">Mes rendez-vous</h1>
+      <p>&lt;gestion des rendez-vous&gt;</p>
+    </main>
   )
 }

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
           <Link href="/" className="hover:underline">Diagnostic</Link>
           <Link href="/contact" className="hover:underline">Contact</Link>
           {connected ? (
-            <Link href="/dashboard" className="hover:underline">Mon espace</Link>
+            <Link href="/client" className="hover:underline">Mon espace</Link>
           ) : (
             <Link href="/login" className="hover:underline">Connexion</Link>
           )}

--- a/src/app/components/Tabs.tsx
+++ b/src/app/components/Tabs.tsx
@@ -1,0 +1,27 @@
+"use client"
+import { useState } from 'react'
+
+export type Tab = {
+  label: string
+  content: React.ReactNode
+}
+
+export default function Tabs({ tabs }: { tabs: Tab[] }) {
+  const [active, setActive] = useState(0)
+  return (
+    <div>
+      <div className="flex space-x-4 border-b mb-4">
+        {tabs.map((t, i) => (
+          <button
+            key={i}
+            onClick={() => setActive(i)}
+            className={`pb-2 font-medium ${i === active ? 'border-b-2 border-[#187072]' : 'text-gray-500'}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div>{tabs[active]?.content}</div>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,14 +17,14 @@ export default function Login() {
 
   useEffect(() => {
     return onAuthStateChanged(auth, (user) => {
-      if (user) router.replace("/dashboard");
+      if (user) router.replace("/client");
     });
   }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     await signInWithEmailAndPassword(auth, email, password);
-    router.replace("/dashboard");
+    router.replace("/client");
   };
 
   return (


### PR DESCRIPTION
## Summary
- add a layout for all client pages
- create a tab component and client dashboard page
- link header and login redirect to `/client`
- adjust client pages to use the new layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9deb0a48832e9aeaed586cc55da1