### PR TITLE
Fix admin user detail route typing

### DIFF
--- a/src/app/admin/utilisateurs/[uid]/page.tsx
+++ b/src/app/admin/utilisateurs/[uid]/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 export const dynamic = "force-dynamic"
 
+import type { PageProps } from 'next'
 import Header from '../../../components/Header'
 import Footer from '../../../components/Footer'
 
-export default function AdminUserDetail({ params }: { params: { uid: string } }) {
+export default function AdminUserDetail({ params }: PageProps<{ uid: string }>) {
   return (
     <>
       <Header />


### PR DESCRIPTION
## Summary
- fix dynamic `[uid]` page typing by using `PageProps`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecac4b92c832e8cec94ebb51e9f4f