### PR TITLE
Add Firebase seed script and fix admin page props

### DIFF
--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -1,0 +1,65 @@
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+    }),
+  });
+}
+
+const auth = admin.auth();
+const db = admin.firestore();
+
+async function run() {
+  const users = [
+    {
+      email: 'client@example.com',
+      password: 'azerty',
+      prenom: 'Sarah',
+      nom: '',
+      role: 'client',
+      plan: 'basic',
+      score: 0,
+    },
+    {
+      email: 'admin@example.com',
+      password: 'azerty',
+      prenom: 'Fred',
+      nom: '',
+      role: 'admin',
+      plan: 'basic',
+      score: 0,
+    },
+  ];
+
+  for (const u of users) {
+    try {
+      const userRecord = await auth.createUser({
+        email: u.email,
+        password: u.password,
+        displayName: `${u.prenom} ${u.nom}`.trim(),
+      });
+
+      await db
+        .collection('utilisateurs')
+        .doc(userRecord.uid)
+        .set({
+          prenom: u.prenom,
+          nom: u.nom,
+          email: u.email,
+          role: u.role,
+          plan: u.plan,
+          score: u.score,
+        });
+
+      console.log(`Created ${u.email} (${userRecord.uid})`);
+    } catch (err) {
+      console.error(`Error creating ${u.email}:`, err.message);
+    }
+  }
+}
+
+run().then(() => process.exit());

--- a/src/app/admin/utilisateurs/[uid]/page.tsx
+++ b/src/app/admin/utilisateurs/[uid]/page.tsx
@@ -1,11 +1,16 @@
 "use client"
 export const dynamic = "force-dynamic"
 
-import type { PageProps } from 'next'
 import Header from '../../../components/Header'
 import Footer from '../../../components/Footer'
 
-export default function AdminUserDetail({ params }: PageProps<{ uid: string }>) {
+interface AdminUserDetailProps {
+  params: {
+    uid: string
+  }
+}
+
+export default function AdminUserDetail({ params }: AdminUserDetailProps) {
   return (
     <>
       <Header />


### PR DESCRIPTION
## Summary
- add `scripts/seed-users.js` for creating initial Firebase users and Firestore docs
- correct props type in `src/app/admin/utilisateurs/[uid]/page.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eccd96bc0832ea1e55dbb6ea890c3