### PR TITLE
Add modular budget tracking components

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "firebase-functions": "^3.23.0",
     "next": "^15.3.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/components/EvolutionMensuelle.tsx
+++ b/src/app/components/EvolutionMensuelle.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+import { Mouvement, Groupe } from "./types";
+import RepartitionBudget from "./RepartitionBudget";
+
+export default function EvolutionMensuelle({
+  mouvements,
+}: {
+  mouvements: Mouvement[];
+}) {
+  const months = Array.from(new Set(mouvements.map(m => m.mois))).sort();
+  const [selected, setSelected] = useState(months[months.length - 1] || "");
+
+  const filterMonth = (mois: string) =>
+    mouvements.filter(m => m.mois === mois);
+
+  const resume = (mois: string) => {
+    const list = filterMonth(mois);
+    const revenu = list
+      .filter(m => m.groupe === "Revenus")
+      .reduce((s, m) => s + m.montant, 0);
+    const dep = list
+      .filter(m => m.groupe !== "Revenus" && m.groupe !== "Ignoré")
+      .reduce((s, m) => s + m.montant, 0);
+    return { revenu, dep, solde: revenu - dep };
+  };
+
+  return (
+    <div className="space-y-4">
+      {months.length > 0 && (
+        <div className="flex justify-center">
+          <select
+            value={selected}
+            onChange={e => setSelected(e.target.value)}
+            className="border rounded p-2"
+          >
+            {months.map(m => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <RepartitionBudget mouvements={filterMonth(selected)} />
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="text-left p-2">Mois</th>
+            <th className="text-right p-2">Revenus</th>
+            <th className="text-right p-2">Dépenses</th>
+            <th className="text-right p-2">Solde</th>
+          </tr>
+        </thead>
+        <tbody>
+          {months.map(m => {
+            const r = resume(m);
+            return (
+              <tr key={m} className="border-b hover:bg-gray-50">
+                <td className="p-2">{m}</td>
+                <td className="p-2 text-right">{r.revenu.toFixed(2)} €</td>
+                <td className="p-2 text-right">{r.dep.toFixed(2)} €</td>
+                <td className="p-2 text-right">{r.solde.toFixed(2)} €</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/components/FormulaireBudget.tsx
+++ b/src/app/components/FormulaireBudget.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState } from "react";
+import { Mouvement, Groupe, groupes } from "./types";
+
+interface Props {
+  initial?: Mouvement;
+  onSubmit: (data: Omit<Mouvement, "id" | "mois">) => void;
+  onCancel?: () => void;
+}
+
+export default function FormulaireBudget({ initial, onSubmit, onCancel }: Props) {
+  const [nom, setNom] = useState(initial?.nom || "");
+  const [montant, setMontant] = useState(initial ? String(initial.montant) : "0");
+  const [groupe, setGroupe] = useState<Groupe>(initial?.groupe || "Revenus");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = parseFloat(montant);
+    if (!nom || isNaN(value) || value <= 0) return;
+    onSubmit({ nom, montant: value, groupe });
+    if (!initial) {
+      setNom("");
+      setMontant("0");
+      setGroupe("Revenus");
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div className="flex flex-col">
+        <label className="font-medium">Nom</label>
+        <input
+          type="text"
+          value={nom}
+          onChange={e => setNom(e.target.value)}
+          className="border rounded p-2"
+          required
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="font-medium">Montant</label>
+        <input
+          type="number"
+          min="0"
+          step="0.01"
+          value={montant}
+          onChange={e => setMontant(e.target.value)}
+          className="border rounded p-2"
+          required
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="font-medium">Groupe</label>
+        <select
+          value={groupe}
+          onChange={e => setGroupe(e.target.value as Groupe)}
+          className="border rounded p-2"
+        >
+          {groupes.map(g => (
+            <option key={g} value={g}>
+              {g}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-x-2">
+        <button type="submit" className="bg-[#187072] text-white py-2 px-4 rounded">
+          {initial ? "Enregistrer" : "Ajouter"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="py-2 px-4 border rounded"
+          >
+            Annuler
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/app/components/ModalEdition.tsx
+++ b/src/app/components/ModalEdition.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { ReactNode } from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function ModalEdition({ open, onClose, children }: Props) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white p-4 rounded shadow w-full max-w-sm">
+        {children}
+        <button
+          onClick={onClose}
+          className="mt-4 w-full bg-[#187072] text-white py-2 rounded"
+        >
+          Fermer
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/RepartitionBudget.tsx
+++ b/src/app/components/RepartitionBudget.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { Mouvement, Groupe } from "./types";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Pie } from "react-chartjs-2";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+export default function RepartitionBudget({
+  mouvements,
+}: {
+  mouvements: Mouvement[];
+}) {
+  const somme = (g: Groupe) =>
+    mouvements
+      .filter(m => m.groupe === g)
+      .reduce((sum, m) => sum + m.montant, 0);
+
+  const besoins = somme("Besoins pour vivre");
+  const loisirs = somme("Plaisirs et loisirs");
+  const liberte = somme("Liberté financière");
+
+  const data = {
+    labels: ["Besoins", "Loisirs", "Liberté"],
+    datasets: [
+      {
+        data: [besoins, loisirs, liberte],
+        backgroundColor: ["#187072", "#26436E", "#E8F3FA"],
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <Pie data={data} />
+    </div>
+  );
+}

--- a/src/app/components/ResumeBudget.tsx
+++ b/src/app/components/ResumeBudget.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { Mouvement, Groupe } from "./types";
+
+export default function ResumeBudget({
+  mouvements,
+}: {
+  mouvements: Mouvement[];
+}) {
+  const somme = (g: Groupe) =>
+    mouvements
+      .filter(m => m.groupe === g)
+      .reduce((sum, m) => sum + m.montant, 0);
+
+  const revenu = somme("Revenus");
+  const depenses = mouvements
+    .filter(m => m.groupe !== "Revenus" && m.groupe !== "Ignoré")
+    .reduce((sum, m) => sum + m.montant, 0);
+  const solde = revenu - depenses;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 text-center">
+      <div className="bg-white p-4 rounded shadow">
+        <p className="text-sm text-gray-500">Revenu</p>
+        <p className="text-xl font-bold text-[#187072]">{revenu.toFixed(2)} €</p>
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <p className="text-sm text-gray-500">Solde</p>
+        <p className="text-xl font-bold text-[#187072]">{solde.toFixed(2)} €</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/TableauMouvements.tsx
+++ b/src/app/components/TableauMouvements.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { Mouvement } from "./types";
+
+interface Props {
+  mouvements: Mouvement[];
+  onEdit: (m: Mouvement) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function TableauMouvements({
+  mouvements,
+  onEdit,
+  onDelete,
+}: Props) {
+  return (
+    <table className="w-full text-sm mt-8">
+      <thead>
+        <tr className="border-b">
+          <th className="text-left p-2">Nom</th>
+          <th className="text-right p-2">Montant</th>
+          <th className="text-left p-2">Groupe</th>
+          <th className="p-2"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {mouvements.map(m => (
+          <tr key={m.id} className="border-b hover:bg-gray-50">
+            <td className="p-2">{m.nom}</td>
+            <td className="p-2 text-right">{m.montant.toFixed(2)} €</td>
+            <td className="p-2">{m.groupe}</td>
+            <td className="p-2 text-right space-x-2">
+              <button
+                onClick={() => onEdit(m)}
+                className="px-2 py-1 text-xs bg-[#26436E] text-white rounded"
+              >
+                Modifier
+              </button>
+              <button
+                onClick={() => onDelete(m.id)}
+                className="px-2 py-1 text-xs bg-red-500 text-white rounded"
+              >
+                Supprimer
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -1,0 +1,8 @@
+export { default as ResumeBudget } from "./ResumeBudget";
+export { default as TableauMouvements } from "./TableauMouvements";
+export { default as FormulaireBudget } from "./FormulaireBudget";
+export { default as ModalEdition } from "./ModalEdition";
+export { default as RepartitionBudget } from "./RepartitionBudget";
+export { default as EvolutionMensuelle } from "./EvolutionMensuelle";
+export { default as SuiviBudget } from "./SuiviBudget";
+export * from "./types";

--- a/src/app/components/types.ts
+++ b/src/app/components/types.ts
@@ -1,0 +1,22 @@
+export type Groupe =
+  | "Revenus"
+  | "Besoins pour vivre"
+  | "Plaisirs et loisirs"
+  | "Liberté financière"
+  | "Ignoré";
+
+export interface Mouvement {
+  id: number;
+  nom: string;
+  montant: number;
+  groupe: Groupe;
+  mois: string; // YYYY-MM
+}
+
+export const groupes: Groupe[] = [
+  "Revenus",
+  "Besoins pour vivre",
+  "Plaisirs et loisirs",
+  "Liberté financière",
+  "Ignoré",
+];


### PR DESCRIPTION
## Summary
- add reusable budget tracking components with Tailwind CSS
- provide types and central exports
- integrate new components in `SuiviBudget`
- include chart.js packages for pie charts

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742f157888832e8a194ff71f7a9780